### PR TITLE
Add a global Contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 This is an organization-wide Contributing.md, which lists the default expectations and norms for contributing to any repository in @bosonprotocol. Any local Contributing.md can override this, but this is meant to be a source of truth for how to work together effectively.
 
+## Style Guide
+
+### Markdown
+
+- For markdown, use `#` instead of `===`.
+
+### Grammar
+
+- Capitalize "Code of Conduct".
+
 ## Tests
 
 All commits in a pull request should pass tests before being submitted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+This is an organization-wide Contributing.md, which lists the default expectations and norms for contributing to any repository in @bosonprotocol. Any local Contributing.md can override this, but this is meant to be a source of truth for how to work together effectively.
+
+## Tests
+
+All commits in a pull request should pass tests before being submitted.
+
+## Branch naming schemas
+
+Please keep branch names to `a-zA-Z0-9-` (alphanumeric characters, and `-`).
+
+## Attribution
+
+When possible, we use [`git authors`](https://github.com/tj/git-extras/blob/master/Commands.md#git-authors) to automatically source contributors for both `package.json` files and for a `CONTRIBUTORS.md` doc in repositories. However, this only counts _code contributions_ from developers, which is not the only type of contribution; there are many other types, like offering design or advice.
+
+In these cases, names may be added to the Contributors list if someone suggests that name.
+
+## Something missing?
+
+If there's a norm or a rule missing, please add it in a Pull Request, or open an issue.


### PR DESCRIPTION
I think this is a good way to set global norms. This relates to https://github.com/bosonprotocol/token-contract/pull/11\#issuecomment-805593226 and https://github.com/bosonprotocol/community/issues/6.