### PR TITLE
Remove Gitter badge and add Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Community
 
-[![Gitter chat](https://badges.gitter.im/bosonprotocol.png)](https://gitter.im/bosonprotocol/community)
+[Join our Discord](https://discord.com/invite/QSdtKRaap6)
 
 This repository is for:
 


### PR DESCRIPTION
It makes sense to concentrate activity in Discord for now, so I've removed the Gitter badge.